### PR TITLE
Enable cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ module.exports = function(taskCallback) {
         if (cache[path]) {
             return cache[path]
         }
+        if (opt.watch !== false) {
+            opt = merge(opt, watchify.args)
+        }
         var bundle = browserify(opt)
         if (opt.watch !== false) {
             watchify(bundle, opt) // modifies bundle to emit update events


### PR DESCRIPTION
When I rebuild large file, gulp-watchify is slow.

```
[15:06:48] Rebundling large.js (watch mode)
1823489 bytes written (1.70 seconds)
```

I outputed execute time by bundle's `log` event.

```javascript
.pipe(watchify({
    watch: true,
    setup: function(bundle) {
      // output log
      bundle.on('log', console.log.bind(console));
    }
}))
```

We can enable cache by setting `watchify.args` to options.

https://github.com/substack/watchify#var-w--watchifyb-opts

After applied this patch:

```
[15:06:48] Rebundling large.js (watch mode)
1897725 bytes written (0.19 seconds)
```

It's 10x faster!